### PR TITLE
Change Endpoint

### DIFF
--- a/prod/structure_number_of_beta_sheets_pdb.md
+++ b/prod/structure_number_of_beta_sheets_pdb.md
@@ -13,7 +13,7 @@
         - The beta-sheets value contained in each entry.
 ## Endpoint
 
-https://integbio.jp/togosite/sparql
+https://integbio.jp/rdf/pdb/sparql
 
 ## `withAnnotation`
 


### PR DESCRIPTION
PDBのデータ更新でグラフ構造の一部変更があり、
SPARQLが未修正のためEndpointを古い物に変更。