### PR TITLE
Change Endpoint

### DIFF
--- a/prod/structure_number_of_peptides_pdb.md
+++ b/prod/structure_number_of_peptides_pdb.md
@@ -14,7 +14,7 @@
 
 ## Endpoint
 
-https://integbio.jp/togosite/sparql
+https://integbio.jp/rdf/pdb/sparql
 
 ## `withAnnotation`
 


### PR DESCRIPTION
PDBのデータ更新でグラフ構造の一部変更があり、
SPARQLが未修正のためEndpointを古い物に変更。